### PR TITLE
refactor: Move the PEM encoder functions to the main library

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"os"
 
@@ -16,42 +14,41 @@ const (
 )
 
 func main() {
-	privateKey, publicKey, err := rotator.RotatePrivateKeyAndPublicKey()
+
+	var (
+		err              error
+		privateKey       *rsa.PrivateKey
+		publicKey        *rsa.PublicKey
+		encodedPublicKey []byte
+	)
+
+	privateKey, publicKey, err = rotator.RotatePrivateKeyAndPublicKey()
+
 	if err != nil {
 		fmt.Printf("Error rotating keys: %s\n", err)
+
 		return
 	}
 
-	if err := writePEMToFile(privateKeyFileName, encodePrivateKeyToPEM(privateKey)); err != nil {
+	if err := writePEMToFile(privateKeyFileName, rotator.EncodePrivateKeyToPEM(privateKey)); err != nil {
 		fmt.Printf("Error writing private key to file: %s\n", err)
+
 		return
 	}
 
-	if err := writePEMToFile(publicKeyFileName, encodePublicKeyToPEM(publicKey)); err != nil {
+	if encodedPublicKey, err = rotator.EncodePublicKeyToPEM(publicKey); err != nil {
+		fmt.Printf("Error encoding public key: %s\n", err)
+
+		return
+	}
+
+	if err = writePEMToFile(publicKeyFileName, encodedPublicKey); err != nil {
 		fmt.Printf("Error writing public key to file: %s\n", err)
+
 		return
 	}
 
 	fmt.Println("Keys successfully rotated and saved.")
-}
-
-// Function to encode an RSA private key to PEM format
-func encodePrivateKeyToPEM(privateKey *rsa.PrivateKey) []byte {
-	privateKeyPEM := &pem.Block{
-		Type:  rotator.RSATypePrivate,
-		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
-	}
-	return pem.EncodeToMemory(privateKeyPEM)
-}
-
-// Function to encode an RSA public key to PEM format
-func encodePublicKeyToPEM(publicKey *rsa.PublicKey) []byte {
-	publicKeyBytes, _ := x509.MarshalPKIXPublicKey(publicKey) // Error handling is omitted here
-	publicKeyPEM := &pem.Block{
-		Type:  rotator.RSATypePublic,
-		Bytes: publicKeyBytes,
-	}
-	return pem.EncodeToMemory(publicKeyPEM)
 }
 
 // Function to write PEM data to a file

--- a/go_key_rotator.go
+++ b/go_key_rotator.go
@@ -145,14 +145,14 @@ func RotatePrivateKeyAndPublicKey() (*rsa.PrivateKey, *rsa.PublicKey, error) {
 	}
 
 	// Store private key
-	err = SetParameterStoreValue(parameterStoreKeyNamePrivateKey, string(privateKeyPEM), AWSStringSecureString)
+	err = setParameterStoreValue(parameterStoreKeyNamePrivateKey, string(privateKeyPEM), AWSStringSecureString)
 
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Store public key
-	err = SetParameterStoreValue(parameterStoreKeyNamePublicKey, string(publicKeyPEM), AWSStringSecureString)
+	err = setParameterStoreValue(parameterStoreKeyNamePublicKey, string(publicKeyPEM), AWSStringSecureString)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -269,7 +269,7 @@ func getParameterStoreValue(name string) (string, error) {
 	return *param.Parameter.Value, nil
 }
 
-// SetParameterStoreValue stores a given value in the AWS Parameter Store.
+// setParameterStoreValue stores a given value in the AWS Parameter Store.
 //
 // Parameters:
 //
@@ -289,7 +289,7 @@ func getParameterStoreValue(name string) (string, error) {
 // a regular string or an encrypted string (SecureString) based on the 'parameterType'.
 // The 'Overwrite' field in the PutParameterInput struct is set to true, allowing this
 // function to update the value of an existing parameter with the same name.
-func SetParameterStoreValue(parameterName, value, parameterType string) error {
+func setParameterStoreValue(parameterName, value, parameterType string) error {
 	var (
 		err  error
 		sess *session.Session


### PR DESCRIPTION
## Description

- `encodePrivateKeyToPEM` and `encodePublicKeyToPEM` were duplicated across 
the example app and the main library.  This indicated the need to share the functionality.
They were moved to the main library and exported

- `SetParameterStoreValue` should not be an exported fn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new feature for rotating RSA keys, enhancing security measures.
  
- **Refactor**
  - Improved RSA key rotation functions for better performance and reliability.

- **Chores**
  - Updated internal functions for RSA key handling to streamline the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->